### PR TITLE
Equation should use proportional symbol

### DIFF
--- a/04_dice_soln.ipynb
+++ b/04_dice_soln.ipynb
@@ -622,7 +622,7 @@
     "\n",
     "Notice that the denominator, $P(D)$, does not depend on $H$, so it is the same for all hypotheses.  If we multiply by $P(D)$, we get:\n",
     "\n",
-    "$P(H|D) \\sim P(H) ~ P(D|H)$\n",
+    "$P(H|D) \\propto P(H) ~ P(D|H)$\n",
     "\n",
     "which says that the posterior probabilities *are proportional to* the unnormalized posteriors.  In other words, if we leave out $P(D)$, we get the proportions right, but not the total.\n",
     "\n",


### PR DESCRIPTION
The equation should use the proportional symbol (Greek letter alpha) rather than an approximately equals symbol (~). This is as detailed in the subsequent text.